### PR TITLE
42Mac build fixed, changed images to alpine

### DIFF
--- a/backend/Dockerfile.daphne
+++ b/backend/Dockerfile.daphne
@@ -1,13 +1,9 @@
-FROM python:3.8-slim
+FROM python:3.8-alpine
 
 EXPOSE 8001
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y build-essential
-
-RUN pip install --upgrade pip
-
-RUN python3 -m pip install --upgrade pip setuptools wheel
+RUN apk update && apk add --no-cache gcc bash musl-dev jpeg-dev zlib-dev libffi-dev cairo-dev pango-dev gdk-pixbuf-dev
 
 RUN pip install --no-cache-dir \
     daphne \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
 
   # Redis container for the websockets
   redis:
-    image: "redis:latest"
+    image: "redis:7.2.3-alpine"
     container_name: "redis"
     command: ["redis-server", "--bind", "redis", "--port", "6379"]
     # ports:


### PR DESCRIPTION
Changes: redis:latest -> redis:7.3.2-alpine
Daphne python docker image changed to alpine base with dev packages (they are neccessary to install channels-redis)
The project does not work on Firefox in 42Cluster. Does work on Chrome.